### PR TITLE
Fix duplicate command definition

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,1 +1,2 @@
-vim.api.nvim_command('command! Whereami lua require("whereami").whereami()')
+-- Load the module so it can register the :Whereami command
+require("whereami")


### PR DESCRIPTION
## Summary
- load `whereami` module during plugin init so the `:Whereami` command is registered only once

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e2ffcb784832cb54ba0bd2b4e4946