### PR TITLE
Fix Code of Conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Whereami.nvim Code of Conduct](https://github.com/ragnarok22/whereami.nvimblob/master/CODE_OF_CONDUCT.md).
+[Whereami.nvim Code of Conduct](https://github.com/ragnarok22/whereami.nvim/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <>.
 


### PR DESCRIPTION
## Summary
- fix the Code of Conduct URL in `CONTRIBUTING.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e30f064f8832c886e754fe389d3ba