### PR TITLE
Fix icon check for empty string

### DIFF
--- a/lua/whereami/init.lua
+++ b/lua/whereami/init.lua
@@ -44,9 +44,9 @@ end
 M.country = function()
 	local data = get_data()
 	local icon = get_flag(data.country)
-	if not icon then
-		icon = "🌎"
-	end
+        if not icon or icon == "" then
+                icon = "🌎"
+        end
 
 	vim.notify("You are in " .. icon .. data.country, vim.log.levels.INFO, { title = "Where am I?", icon = icon })
 end


### PR DESCRIPTION
## Summary
- handle empty icon strings in `whereami` plugin

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e30e317e4832cbed76e7137909631