### PR TITLE
Add plenary tests for flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ vim.keymap.set("n", "<leader>e", whereami.city, { desc = "Show the city" })
 vim.keymap.set("n", "<leader>i", whereami.ip, { desc = "Show the ip" })
 ```
 
+## Testing
+
+The plugin uses [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) for
+its test suite. You can run the tests from the project root with:
+
+```bash
+nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa
+```
+
+The command requires Neovim and plenary.nvim to be installed.
+
 ## License
 
 [GNU GPLv3](LICENSE)

--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -1,0 +1,41 @@
+local stub = require('luassert.stub')
+local whereami = require('whereami')
+local curl = require('plenary.curl')
+
+-- get reference to the local get_flag function via debug upvalue
+local get_flag = debug.getupvalue(whereami.country, 2)
+
+describe('whereami', function()
+  it('returns proper flag emoji', function()
+    assert.is_function(get_flag)
+    assert.are.equal('🇺🇸', get_flag('US'))
+  end)
+
+  it('uses fallback icon when get_flag returns empty string', function()
+    local curl_stub = stub(curl, 'get', function()
+      return { body = '{"country":"US"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    -- replace get_flag upvalue with stub that returns empty string
+    local original = get_flag
+    debug.setupvalue(whereami.country, 2, function()
+      return ''
+    end)
+
+    whereami.country()
+
+    assert.stub(vim.notify).was_called_with(
+      'You are in 🌎US',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '🌎' }
+    )
+
+    -- revert
+    debug.setupvalue(whereami.country, 2, original)
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+end)
+
+

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,2 @@
+vim.opt.runtimepath:append('.')
+vim.opt.runtimepath:append('lua')


### PR DESCRIPTION
## Summary
- add lua tests using plenary.busted
- create minimal init for tests

## Testing
- `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e30f2955c832c9a5525c9f8170ab6