### PR TITLE
Fix upvalue retrieval in tests

### DIFF
--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -2,8 +2,8 @@ local stub = require('luassert.stub')
 local whereami = require('whereami')
 local curl = require('plenary.curl')
 
--- get reference to the local get_flag function via debug upvalue
-local get_flag = debug.getupvalue(whereami.country, 2)
+-- debug.getupvalue returns the upvalue name and value. We only want the value
+local _, get_flag = debug.getupvalue(whereami.country, 2)
 
 describe('whereami', function()
   it('returns proper flag emoji', function()


### PR DESCRIPTION
## Summary
- in tests, correctly capture the `get_flag` function from `whereami.country`

## Testing
- `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3a6973b8832c88fdc5978a9594fd