### PR TITLE
Add configurable providers, caching, hooks, and expanded API/CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,74 @@ Here is an example of installation using lazy:
 }
 ```
 
+
+## Configuration
+
+`whereami.nvim` works without configuration, but you can call `setup(opts)` to
+override provider fallback behavior, request timeout, notification metadata, default
+command behavior, cache TTL, or request hooks.
+
+```lua
+require("whereami").setup({
+  -- Use one provider URL, or omit this to keep the default ipinfo/ipapi fallback list.
+  provider_url = "https://ipinfo.io/json",
+})
+```
+
+Or define a custom provider or ordered provider list. Each provider can expose
+`url`, `fetch(config)`, and `normalize(data)`.
+
+```lua
+require("whereami").setup({
+  providers = {
+    { url = "https://ipinfo.io/json" },
+    {
+      url = "https://ipapi.co/json/",
+      normalize = function(data)
+        return {
+          ip = data.ip,
+          city = data.city,
+          country = data.country_code,
+          org = data.org or data.asn,
+        }
+      end,
+    },
+  },
+})
+```
+
+Other options can be combined with either provider style:
+
+```lua
+require("whereami").setup({
+  -- Request timeout passed to plenary.curl, in milliseconds.
+  timeout = 5000,
+
+  notification = {
+    title = "Where am I?",
+    icons = {
+      country_fallback = "🌎",
+      default = "❔",
+    },
+  },
+
+  -- Used by `:Whereami` with no argument and by `require("whereami").whereami()`.
+  default_command = "country",
+
+  -- Cache provider responses for this many milliseconds. Set to 0 to disable.
+  cache_ttl = 300000,
+
+  hooks = {
+    before_request = function(config)
+      -- Runs before a provider request.
+    end,
+    after_request = function(data, config)
+      -- Runs after a fresh provider response is decoded.
+    end,
+  },
+})
+```
+
 ## Usage
 
 You can use the command or the API
@@ -75,14 +143,18 @@ Run `:Whereami` to display the country you are in.
 
 You can also provide an argument:
 
-- `:Whereami country`: Show the country location where you request was originated from.
-- `:Whereami city`: Show the city location where you request was originated from.
+- `:Whereami country`: Show the country location where your request originated from.
+- `:Whereami all`: Show a summary with country, city, IP address, and ISP.
+- `:Whereami city`: Show the city location where your request originated from.
 - `:Whereami ip`: Show the IP address where your request originated from.
 - `:Whereami isp`: Show your current internet service provider.
+- `:Whereami refresh`: Clear cached location data, fetch fresh data, then show the country.
 
 ### Health checks
 
-Run `:checkhealth whereami` to verify that `plenary.curl` is available, JSON decoding works, `vim.notify` customization is detected, and the location provider can be reached.
+Run `:checkhealth whereami` to verify that `plenary.curl` is available, JSON
+decoding works, `vim.notify` customization is detected, and the default location
+provider can be reached.
 
 ### API
 
@@ -91,9 +163,12 @@ You can also use the methods, for example for key bindings
 ```lua
 local whereami = require("whereami")
 whereami.country() -- show the country
+whereami.all() -- show country, city, IP, and ISP
 whereami.city() -- show the city
 whereami.ip() -- show the IP
 whereami.isp() -- show the ISP
+whereami.clear_cache() -- clear cached provider data
+whereami.refresh() -- fetch fresh provider data
 
 -- set keymaps
 vim.keymap.set("n", "<leader>l", whereami.country, { desc = "Show the country" })
@@ -101,6 +176,7 @@ vim.keymap.set("n", "<leader>e", whereami.city, { desc = "Show the city" })
 vim.keymap.set("n", "<leader>i", whereami.ip, { desc = "Show the ip" })
 vim.keymap.set("n", "<leader>s", whereami.isp, { desc = "Show the ISP" })
 ```
+
 
 ## Testing
 

--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -2,10 +2,29 @@ local stub = require('luassert.stub')
 local whereami = require('whereami')
 local curl = require('plenary.curl')
 
--- debug.getupvalue returns the upvalue name and value. We only want the value
-local _, get_flag = debug.getupvalue(whereami.country, 2)
+local function get_upvalue(fn, name)
+  local index = 1
+  while true do
+    local upvalue_name, value = debug.getupvalue(fn, index)
+    if not upvalue_name then
+      return nil
+    end
+    if upvalue_name == name then
+      return value, index
+    end
+    index = index + 1
+  end
+end
+
+local notify_country = get_upvalue(whereami.country, 'notify_country')
+local get_country_icon = get_upvalue(notify_country, 'get_country_icon')
+local get_flag = get_upvalue(get_country_icon, 'get_flag')
 
 describe('whereami', function()
+  after_each(function()
+    whereami.setup()
+  end)
+
   it('returns proper flag emoji', function()
     assert.is_function(get_flag)
     assert.are.equal('🇺🇸', get_flag('US'))
@@ -17,9 +36,8 @@ describe('whereami', function()
     end)
     local notify_stub = stub(vim, 'notify')
 
-    -- replace get_flag upvalue with stub that returns empty string
-    local original = get_flag
-    debug.setupvalue(whereami.country, 2, function()
+    local original, get_flag_index = get_upvalue(get_country_icon, 'get_flag')
+    debug.setupvalue(get_country_icon, get_flag_index, function()
       return ''
     end)
 
@@ -31,17 +49,97 @@ describe('whereami', function()
       { title = 'Where am I?', icon = '🌎' }
     )
 
-    -- revert
-    debug.setupvalue(whereami.country, 2, original)
+    debug.setupvalue(get_country_icon, get_flag_index, original)
     curl_stub:revert()
     notify_stub:revert()
   end)
+
+  it('shows all location details in one summary', function()
+    local curl_stub = stub(curl, 'get', function()
+      return {
+        body = '{"country":"US","city":"New York","ip":"203.0.113.10","org":"Example ISP"}',
+      }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.all()
+
+    assert.stub(vim.notify).was_called_with(
+      table.concat({
+        'Country: 🇺🇸US',
+        'City: New York',
+        'IP: 203.0.113.10',
+        'ISP: Example ISP',
+      }, '\n'),
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '🇺🇸' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('configures provider URL, timeout, and notification metadata', function()
+    local curl_stub = stub(curl, 'get', function()
+      return { body = '{"city":"Reykjavik"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.setup({
+      provider_url = 'https://example.test/json',
+      timeout = 1234,
+      notification = {
+        title = 'VPN Check',
+        icons = { default = '📍' },
+      },
+    })
+
+    whereami.city()
+
+    assert.stub(curl.get).was_called_with('https://example.test/json', { timeout = 1234 })
+    assert.stub(vim.notify).was_called_with(
+      'You are in Reykjavik',
+      vim.log.levels.INFO,
+      { title = 'VPN Check', icon = '📍' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('prefers provider_url over configured provider lists', function()
+    local curl_stub = stub(curl, 'get', function()
+      return { body = '{"city":"Reykjavik"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.setup({
+      provider_url = 'https://example.test/json',
+      providers = {
+        { url = 'https://unused.example/json' },
+      },
+    })
+
+    whereami.city()
+
+    assert.stub(curl.get).was_called_with('https://example.test/json', { timeout = 5000 })
+    assert.stub(vim.notify).was_called_with(
+      'You are in Reykjavik',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '❔' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
   it('defaults to country when no command argument is provided', function()
     local country_stub = stub(whereami, 'country')
 
     vim.cmd('Whereami')
 
     assert.stub(whereami.country).was_called(1)
+
     country_stub:revert()
   end)
 
@@ -52,7 +150,7 @@ describe('whereami', function()
     vim.cmd('Whereami foo')
 
     assert.stub(vim.notify).was_called_with(
-      'Unknown option: foo\nAvailable options: country, city, ip, isp',
+      'Unknown option: foo\nAvailable options: all, city, country, ip, isp, refresh',
       vim.log.levels.WARN,
       { title = 'Where am I?' }
     )
@@ -61,6 +159,7 @@ describe('whereami', function()
     country_stub:revert()
     notify_stub:revert()
   end)
+
   it('notifies when trailing command arguments are provided after a known option', function()
     local notify_stub = stub(vim, 'notify')
     local country_stub = stub(whereami, 'country')
@@ -68,7 +167,7 @@ describe('whereami', function()
     vim.cmd('Whereami country foo')
 
     assert.stub(vim.notify).was_called_with(
-      'Unknown option: foo\nAvailable options: country, city, ip, isp',
+      'Unknown option: foo\nAvailable options: all, city, country, ip, isp, refresh',
       vim.log.levels.WARN,
       { title = 'Where am I?' }
     )
@@ -78,6 +177,231 @@ describe('whereami', function()
     notify_stub:revert()
   end)
 
+  it('falls back to the next default provider when the first provider fails', function()
+    local calls = 0
+    local curl_stub = stub(curl, 'get', function(url)
+      calls = calls + 1
+      if url == 'https://ipinfo.io/json' then
+        error('ipinfo unavailable')
+      end
+
+      return { body = '{"country":"CA","city":"Toronto"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.country()
+
+    assert.are.equal(2, calls)
+    assert.stub(vim.notify).was_called_with(
+      'You are in 🇨🇦CA',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '🇨🇦' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('falls back when a provider response has no location fields', function()
+    local calls = 0
+    local curl_stub = stub(curl, 'get', function(url)
+      calls = calls + 1
+      if url == 'https://ipinfo.io/json' then
+        return { status = 200, body = '{"error":"rate limited"}' }
+      end
+
+      return { status = 200, body = '{"country_code":"CA","city":"Toronto"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.country()
+
+    assert.are.equal(2, calls)
+    assert.stub(vim.notify).was_called_with(
+      'You are in 🇨🇦CA',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '🇨🇦' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('falls back when a provider returns a non-success HTTP status', function()
+    local calls = 0
+    local curl_stub = stub(curl, 'get', function(url)
+      calls = calls + 1
+      if url == 'https://ipinfo.io/json' then
+        return { status = 429, body = '{"error":"quota exceeded"}' }
+      end
+
+      return { status = 200, body = '{"country_code":"CA","city":"Toronto"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.country()
+
+    assert.are.equal(2, calls)
+    assert.stub(vim.notify).was_called_with(
+      'You are in 🇨🇦CA',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '🇨🇦' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('supports custom provider tables with fetch handlers', function()
+    local curl_stub = stub(curl, 'get', function()
+      error('curl should not be used for custom providers')
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.setup({
+      providers = {
+        fetch = function()
+          return '{"city":"Berlin","country":"DE"}'
+        end,
+        normalize = function(data)
+          return {
+            city = data.city,
+            country = data.country,
+          }
+        end,
+      },
+    })
+
+    whereami.city()
+
+    assert.stub(vim.notify).was_called_with(
+      'You are in Berlin',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '❔' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('uses cache TTL and request hooks', function()
+    local calls = 0
+    local before_calls = 0
+    local after_calls = 0
+    local curl_stub = stub(curl, 'get', function()
+      calls = calls + 1
+      return { body = '{"ip":"127.0.0.' .. calls .. '"}' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.setup({
+      cache_ttl = 1000,
+      hooks = {
+        before_request = function()
+          before_calls = before_calls + 1
+        end,
+        after_request = function()
+          after_calls = after_calls + 1
+        end,
+      },
+    })
+
+    whereami.ip()
+    whereami.ip()
+
+    assert.are.equal(1, calls)
+    assert.are.equal(1, before_calls)
+    assert.are.equal(1, after_calls)
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('notifies instead of raising when the network request fails', function()
+    local curl_stub = stub(curl, 'get', function()
+      error('network unavailable')
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    assert.has_no.errors(function()
+      whereami.country()
+    end)
+
+    assert.stub(vim.notify).was_called_with(
+      'Unable to fetch location data.',
+      vim.log.levels.ERROR,
+      { title = 'Where am I?', icon = '❌' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('notifies instead of raising when the response is invalid JSON', function()
+    local curl_stub = stub(curl, 'get', function()
+      return { body = 'not-json' }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    assert.has_no.errors(function()
+      whereami.city()
+    end)
+
+    assert.stub(vim.notify).was_called_with(
+      'Unable to parse location data.',
+      vim.log.levels.ERROR,
+      { title = 'Where am I?', icon = '❌' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('does not run a second refresh cycle when refresh command fails', function()
+    local calls = 0
+    local curl_stub = stub(curl, 'get', function()
+      calls = calls + 1
+      error('network unavailable')
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    vim.cmd('Whereami refresh')
+
+    assert.are.equal(2, calls)
+    assert.stub(vim.notify).was_called_with(
+      'Unable to fetch location data.',
+      vim.log.levels.ERROR,
+      { title = 'Where am I?', icon = '❌' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
+
+  it('refreshes cached data on demand', function()
+    local responses = {
+      '{"country":"US","city":"New York"}',
+      '{"country":"CA","city":"Toronto"}',
+    }
+    local calls = 0
+    local curl_stub = stub(curl, 'get', function()
+      calls = calls + 1
+      return { body = responses[calls] }
+    end)
+    local notify_stub = stub(vim, 'notify')
+
+    whereami.city()
+    whereami.refresh()
+    whereami.city()
+
+    assert.are.equal(2, calls)
+    assert.stub(vim.notify).was_called_with(
+      'You are in Toronto',
+      vim.log.levels.INFO,
+      { title = 'Where am I?', icon = '❔' }
+    )
+
+    curl_stub:revert()
+    notify_stub:revert()
+  end)
 end)
-
-

--- a/lua/whereami/health.lua
+++ b/lua/whereami/health.lua
@@ -1,7 +1,6 @@
 local M = {}
 
-local PROVIDER_URL = "https://ipinfo.io"
-
+local PROVIDER_URL = "https://ipinfo.io/json"
 local health = vim.health or {}
 
 local function start(name)

--- a/lua/whereami/init.lua
+++ b/lua/whereami/init.lua
@@ -1,29 +1,98 @@
 local M = {}
-local curl = require("plenary.curl")
+local providers = require("whereami.providers")
 
-local available_options = { "country", "city", "ip", "isp" }
+local available_options = { "all", "city", "country", "ip", "isp", "refresh" }
 
 local function available_options_text()
 	return table.concat(available_options, ", ")
+end
+
+local function is_available_option(option)
+	return vim.tbl_contains(available_options, option)
+end
+
+local default_config = {
+	providers = nil,
+	provider_url = nil,
+	timeout = 5000,
+	notification = {
+		title = "Where am I?",
+		icons = {
+			country_fallback = "🌎",
+			default = "❔",
+		},
+	},
+	default_command = "country",
+	cache_ttl = 300000,
+	hooks = {
+		before_request = nil,
+		after_request = nil,
+	},
+}
+
+local config = vim.deepcopy(default_config)
+local cache = {
+	data = nil,
+	updated_at = 0,
+}
+
+local function merge_config(opts)
+	config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), opts or {})
+end
+
+local function notify_error(message)
+	vim.notify(message, vim.log.levels.ERROR, { title = config.notification.title, icon = "❌" })
 end
 
 local function notify_unknown_option(option)
 	vim.notify(
 		"Unknown option: " .. option .. "\nAvailable options: " .. available_options_text(),
 		vim.log.levels.WARN,
-		{ title = "Where am I?" }
+		{ title = config.notification.title }
 	)
 end
 
-local function get_data()
-	local IP_URL = "ipinfo.io"
-	local data = vim.json.decode(curl.get(IP_URL).body)
-	return data
+local function get_data(opts)
+	opts = opts or {}
+	local now = vim.loop.now()
+	if not opts.refresh and config.cache_ttl > 0 and cache.data and (now - cache.updated_at) < config.cache_ttl then
+		return cache.data
+	end
+
+	if config.hooks.before_request then
+		config.hooks.before_request(config)
+	end
+
+	local parse_error = false
+	for _, provider in ipairs(providers.list(config)) do
+		local data, err = providers.fetch(provider, config)
+		if data then
+			cache.data = data
+			cache.updated_at = vim.loop.now()
+
+			if config.hooks.after_request then
+				config.hooks.after_request(data, config)
+			end
+
+			return data
+		end
+		parse_error = parse_error or err == "Unable to parse location data."
+	end
+
+	if parse_error then
+		return nil, "Unable to parse location data."
+	end
+	return nil, "Unable to fetch location data."
 end
 
 -- TODO: find a better way to do this. So far utf8.char() is the only way I found but is not available in lua 5.1
 local function get_flag(country_iso)
 	local flag_icon = ""
+	if type(country_iso) ~= "string" then
+		return flag_icon
+	end
+
+	country_iso = country_iso:upper()
 	for i = 1, #country_iso do
 		local code_point = country_iso:byte(i) + 127397
 		if code_point <= 0x7F then
@@ -55,59 +124,137 @@ local function get_flag(country_iso)
 	return flag_icon
 end
 
-M.country = function()
-	local data = get_data()
-	local icon = get_flag(data.country)
-        if not icon or icon == "" then
-                icon = "🌎"
-        end
+local function notify(message, icon)
+	vim.notify(message, vim.log.levels.INFO, { title = config.notification.title, icon = icon })
+end
 
-	vim.notify("You are in " .. icon .. data.country, vim.log.levels.INFO, { title = "Where am I?", icon = icon })
+local function get_country_icon(country)
+	local icon = get_flag(country or "")
+	if not icon or icon == "" then
+		icon = config.notification.icons.country_fallback
+	end
+	return icon
+end
+
+local function notify_country(data)
+	local icon = get_country_icon(data.country)
+	notify("You are in " .. icon .. (data.country or "unknown"), icon)
+end
+
+M.setup = function(opts)
+	merge_config(opts)
+	cache.data = nil
+	cache.updated_at = 0
+end
+
+M.clear_cache = function()
+	cache.data = nil
+	cache.updated_at = 0
+end
+
+M.refresh = function()
+	M.clear_cache()
+	return get_data({ refresh = true })
+end
+
+M.country = function()
+	local data, err = get_data()
+	if not data then
+		notify_error(err)
+		return
+	end
+
+	notify_country(data)
 end
 
 M.city = function()
-	local data = get_data()
-	vim.notify("You are in " .. data.city, vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+	local data, err = get_data()
+	if not data then
+		notify_error(err)
+		return
+	end
+
+	notify("You are in " .. (data.city or "unknown"), config.notification.icons.default)
 end
 
 M.ip = function()
-	local data = get_data()
-	vim.notify("You IP is " .. data.ip, vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+	local data, err = get_data()
+	if not data then
+		notify_error(err)
+		return
+	end
+
+	notify("Your IP is " .. (data.ip or "unknown"), config.notification.icons.default)
 end
 
 M.isp = function()
-	local data = get_data()
-	vim.notify("You ISP is " .. data.org, vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+	local data, err = get_data()
+	if not data then
+		notify_error(err)
+		return
+	end
+
+	notify("Your ISP is " .. (data.org or "unknown"), config.notification.icons.default)
+end
+
+M.all = function()
+	local data, err = get_data()
+	if not data then
+		notify_error(err)
+		return
+	end
+
+	local icon = get_country_icon(data.country)
+	local summary = table.concat({
+		"Country: " .. icon .. (data.country or "unknown"),
+		"City: " .. (data.city or "unknown"),
+		"IP: " .. (data.ip or "unknown"),
+		"ISP: " .. (data.org or "unknown"),
+	}, "\n")
+
+	notify(summary, icon)
 end
 
 M.whereami = function()
-	M.country()
+	local handler = M[config.default_command] or M.country
+	handler()
 end
 
 vim.api.nvim_create_user_command("Whereami", function(opts)
 	local option = opts.fargs[1]
 	local extra_option = opts.fargs[2]
-
 	if extra_option ~= nil then
 		notify_unknown_option(extra_option)
-	elseif option == nil then
-		M.country()
-	elseif option == "country" then
-		M.country()
-	elseif option == "city" then
-		M.city()
-	elseif option == "ip" then
-		M.ip()
-	elseif option == "isp" then
-		M.isp()
+		return
+	end
+
+	if option == nil then
+		local handler = M[config.default_command] or M.country
+		handler()
+		return
+	end
+
+	if option == "refresh" then
+		local data, err = M.refresh()
+		if not data then
+			notify_error(err)
+			return
+		end
+		notify_country(data)
+		return
+	end
+
+	if is_available_option(option) then
+		M[option]()
 	else
 		notify_unknown_option(option)
 	end
 end, {
 	nargs = "*",
-	complete = function(ArgLead, CmdLine, CursorPos)
-		-- return completion candidates as a list-like table
-		return available_options
+	complete = function(arg_lead)
+		return vim.tbl_filter(function(candidate)
+			return vim.startswith(candidate, arg_lead)
+		end, available_options)
 	end,
 	desc = "Location where the current location was originated from.",
 })

--- a/lua/whereami/providers.lua
+++ b/lua/whereami/providers.lua
@@ -1,0 +1,135 @@
+local M = {}
+
+local default_providers = {
+	{
+		name = "ipinfo",
+		url = "https://ipinfo.io/json",
+		normalize = function(data)
+			return {
+				ip = data.ip,
+				city = data.city,
+				country = data.country,
+				org = data.org,
+			}
+		end,
+	},
+	{
+		name = "ipapi",
+		url = "https://ipapi.co/json/",
+		normalize = function(data)
+			return {
+				ip = data.ip,
+				city = data.city,
+				country = data.country_code or data.country,
+				org = data.org or data.asn,
+			}
+		end,
+	},
+}
+
+local function normalize_provider(provider)
+	if type(provider) == "string" then
+		return { url = provider }
+	end
+
+	if type(provider) ~= "table" then
+		return nil
+	end
+
+	return provider
+end
+
+local function is_single_provider(provider)
+	if type(provider) ~= "table" then
+		return false
+	end
+
+	return provider.url ~= nil or provider.fetch ~= nil or provider.normalize ~= nil
+end
+
+local function has_location_field(data)
+	return data.ip ~= nil or data.city ~= nil or data.country ~= nil or data.org ~= nil
+end
+
+local function unwrap_response(response)
+	if type(response) ~= "table" or response.body == nil then
+		return response
+	end
+
+	local status = response.status
+	if status and (status < 200 or status >= 300) then
+		return nil
+	end
+
+	return response.body
+end
+
+function M.list(config)
+	config = config or {}
+
+	if config.provider_url then
+		return { { url = config.provider_url } }
+	end
+
+	if type(config.providers) == "string" then
+		return { { url = config.providers } }
+	end
+
+	if is_single_provider(config.providers) then
+		return { config.providers }
+	end
+
+	if type(config.providers) == "table" and #config.providers > 0 then
+		return config.providers
+	end
+
+	return default_providers
+end
+
+function M.fetch(provider, config)
+	provider = normalize_provider(provider)
+	if not provider then
+		return nil
+	end
+
+	local ok, response
+	if provider.fetch then
+		ok, response = pcall(provider.fetch, config)
+	else
+		ok, response = pcall(require("plenary.curl").get, provider.url, { timeout = config.timeout })
+	end
+
+	if not ok or not response or response == "" then
+		return nil
+	end
+
+	response = unwrap_response(response)
+	if not response or response == "" then
+		return nil
+	end
+
+	local data = response
+	if type(response) == "string" then
+		local decode_ok, decoded = pcall(vim.json.decode, response)
+		if not decode_ok or type(decoded) ~= "table" then
+			return nil, "Unable to parse location data."
+		end
+		data = decoded
+	end
+
+	if provider.normalize then
+		local normalize_ok, normalized = pcall(provider.normalize, data)
+		if not normalize_ok then
+			return nil
+		end
+		data = normalized
+	end
+
+	if type(data) ~= "table" or not has_location_field(data) then
+		return nil
+	end
+
+	return data
+end
+
+return M


### PR DESCRIPTION
### Motivation

- Provide configurable provider endpoints, custom provider handlers, and more robust network/error handling to make location lookups reliable and extensible. 
- Add response caching and hooks to reduce network load and allow integrations before/after requests. 
- Expose additional API and CLI behaviors (`all`, `refresh`, `clear_cache`) and improve user-facing notifications and completion. 

### Description

- Introduce a new `lua/whereami/providers.lua` module with default providers, provider listing, fetch, and normalization logic, and update `lua/whereami/init.lua` to use it. 
- Add configuration via `M.setup(opts)` with `provider_url`, `providers`, `timeout`, `notification`, `default_command`, `cache_ttl`, and `hooks`, plus `M.clear_cache()` and `M.refresh()` helpers and caching logic. 
- Add `all` command/API to show a combined summary, improve flag handling and notification helpers, implement error notifications instead of raising, and extend the `Whereami` command completion to include `all` and `refresh`. 
- Update `README.md` with configuration examples and new usage notes. 

### Testing

- Expanded `lua/tests/whereami_spec.lua` to cover flag fallback, `all` summary, custom provider fetch/normalize, provider fallback behavior, cache TTL and hooks, `refresh` behavior, and error notification paths, and the tests were executed with `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa`. 
- All automated tests in the `lua/tests` suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fdf09312c8328957670108c0123d9)