### PR TITLE
Make flag generation safer

### DIFF
--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -1,41 +1,45 @@
 local stub = require('luassert.stub')
 local whereami = require('whereami')
+local flag = require('whereami.flag')
 local curl = require('plenary.curl')
-
--- debug.getupvalue returns the upvalue name and value. We only want the value
-local _, get_flag = debug.getupvalue(whereami.country, 2)
 
 describe('whereami', function()
   it('returns proper flag emoji', function()
-    assert.is_function(get_flag)
-    assert.are.equal('🇺🇸', get_flag('US'))
+    assert.are.equal('🇺🇸', flag.get_flag('US'))
   end)
 
-  it('uses fallback icon when get_flag returns empty string', function()
+  it('uppercases country codes before generating flags', function()
+    assert.are.equal('🇺🇸', flag.get_flag('us'))
+  end)
+
+  it('uses fallback icon for missing country codes', function()
+    assert.are.equal('🌎', flag.get_flag(nil))
+  end)
+
+  it('uses fallback icon for empty country codes', function()
+    assert.are.equal('🌎', flag.get_flag(''))
+  end)
+
+  it('uses fallback icon for invalid country codes', function()
+    assert.are.equal('🌎', flag.get_flag('USA'))
+    assert.are.equal('🌎', flag.get_flag('U1'))
+  end)
+
+  it('uses fallback icon when provider omits country', function()
     local curl_stub = stub(curl, 'get', function()
-      return { body = '{"country":"US"}' }
+      return { body = '{}' }
     end)
     local notify_stub = stub(vim, 'notify')
-
-    -- replace get_flag upvalue with stub that returns empty string
-    local original = get_flag
-    debug.setupvalue(whereami.country, 2, function()
-      return ''
-    end)
 
     whereami.country()
 
     assert.stub(vim.notify).was_called_with(
-      'You are in 🌎US',
+      'You are in 🌎unknown',
       vim.log.levels.INFO,
       { title = 'Where am I?', icon = '🌎' }
     )
 
-    -- revert
-    debug.setupvalue(whereami.country, 2, original)
     curl_stub:revert()
     notify_stub:revert()
   end)
 end)
-
-

--- a/lua/whereami/flag.lua
+++ b/lua/whereami/flag.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+local FALLBACK_ICON = "🌎"
+
+-- TODO: find a better way to do this. So far utf8.char() is the only way I found but is not available in lua 5.1
+function M.get_flag(country_iso)
+	if type(country_iso) ~= "string" or not country_iso:match("^%a%a$") then
+		return FALLBACK_ICON
+	end
+
+	country_iso = country_iso:upper()
+
+	local flag_icon = ""
+	for i = 1, #country_iso do
+		local code_point = country_iso:byte(i) + 127397
+		if code_point <= 0x7F then
+			flag_icon = flag_icon .. string.char(code_point)
+		elseif code_point <= 0x7FF then
+			flag_icon = flag_icon .. string.char(0xC0 + math.floor(code_point / 0x40), 0x80 + code_point % 0x40)
+		elseif code_point <= 0xFFFF then
+			flag_icon = flag_icon
+				.. string.char(
+					0xE0 + math.floor(code_point / 0x1000),
+					0x80 + math.floor((code_point % 0x1000) / 0x40),
+					0x80 + code_point % 0x40
+				)
+		elseif code_point <= 0x10FFFF then
+			flag_icon = flag_icon
+				.. string.char(
+					0xF0 + math.floor(code_point / 0x40000),
+					0x80 + math.floor((code_point % 0x40000) / 0x1000),
+					0x80 + math.floor((code_point % 0x1000) / 0x40),
+					0x80 + code_point % 0x40
+				)
+		end
+	end
+
+	-- for i = 1, #country_iso do
+	--     local charCode = string.byte(country_iso:sub(i, i)) + 127397
+	--     flag_icon = flag_icon .. utf8.char(charCode)
+	-- end
+	return flag_icon
+end
+
+return M

--- a/lua/whereami/init.lua
+++ b/lua/whereami/init.lua
@@ -1,5 +1,6 @@
 local M = {}
 local curl = require("plenary.curl")
+local flag = require("whereami.flag")
 
 local function get_data()
 	local IP_URL = "ipinfo.io"
@@ -7,48 +8,13 @@ local function get_data()
 	return data
 end
 
--- TODO: find a better way to do this. So far utf8.char() is the only way I found but is not available in lua 5.1
-local function get_flag(country_iso)
-	local flag_icon = ""
-	for i = 1, #country_iso do
-		local code_point = country_iso:byte(i) + 127397
-		if code_point <= 0x7F then
-			flag_icon = flag_icon .. string.char(code_point)
-		elseif code_point <= 0x7FF then
-			flag_icon = flag_icon .. string.char(0xC0 + math.floor(code_point / 0x40), 0x80 + code_point % 0x40)
-		elseif code_point <= 0xFFFF then
-			flag_icon = flag_icon
-				.. string.char(
-					0xE0 + math.floor(code_point / 0x1000),
-					0x80 + math.floor((code_point % 0x1000) / 0x40),
-					0x80 + code_point % 0x40
-				)
-		elseif code_point <= 0x10FFFF then
-			flag_icon = flag_icon
-				.. string.char(
-					0xF0 + math.floor(code_point / 0x40000),
-					0x80 + math.floor((code_point % 0x40000) / 0x1000),
-					0x80 + math.floor((code_point % 0x1000) / 0x40),
-					0x80 + code_point % 0x40
-				)
-		end
-	end
-
-	-- for i = 1, #country_iso do
-	--     local charCode = string.byte(country_iso:sub(i, i)) + 127397
-	--     flag_icon = flag_icon .. utf8.char(charCode)
-	-- end
-	return flag_icon
-end
 
 M.country = function()
 	local data = get_data()
-	local icon = get_flag(data.country)
-        if not icon or icon == "" then
-                icon = "🌎"
-        end
+	local country = data.country or "unknown"
+	local icon = flag.get_flag(data.country)
 
-	vim.notify("You are in " .. icon .. data.country, vim.log.levels.INFO, { title = "Where am I?", icon = icon })
+	vim.notify("You are in " .. icon .. country, vim.log.levels.INFO, { title = "Where am I?", icon = icon })
 end
 
 M.city = function()


### PR DESCRIPTION
### Motivation
- Prevent errors when provider responses omit `country` by guarding flag generation against nil, empty, or malformed values.
- Make flag generation deterministic by uppercasing valid country codes before converting to emoji.
- Improve testability by exposing the flag helper from a public module instead of relying on `debug.getupvalue` tricks.

### Description
- Extracted flag logic to a new `whereami.flag` module and exposed `get_flag` for direct use and testing.
- Added input guards to `get_flag` to return a fallback globe icon for non-strings, empty, or non-two-letter country codes and uppercase valid country codes before generating emoji.
- Updated `whereami.country()` to use `flag.get_flag`, default the displayed country to `"unknown"` when missing, and avoid concatenating `nil`.
- Reworked tests in `lua/tests/whereami_spec.lua` to require `whereami.flag` directly and added cases for nil, empty, lowercase, and invalid country codes while removing `debug.getupvalue` usage.

### Testing
- Ran `git diff --check` which succeeded.
- Attempted to run the Plenary Busted test suite via `nvim --headless` but it was not executed because `nvim` is not installed in the environment.
- Attempted to run quick `lua -e` assertions to exercise `whereami.flag`, but they were not executed because `lua` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff172897483289666d7d4b166cf86)