### PR TITLE
Split whereami into config, cache, and format modules

### DIFF
--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -398,10 +398,8 @@ describe("whereami", function()
 		notify_stub:revert()
 	end)
 
-
 	it("formats private location fields without fetching data", function()
 		assert.are.equal("203.0.xxx.xxx", format.ip("203.0.113.42", { mask_ip = true }))
-		assert.are.equal("2001:db8:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx", format.ip("2001:db8::1", { mask_ip = true }))
 		assert.are.equal("hidden", format.city("Springfield", { hide_city = true }))
 		assert.are.equal("hidden", format.isp("Example ISP", { hide_isp = true }))
 	end)

--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -1,7 +1,7 @@
 local stub = require("luassert.stub")
 local whereami = require("whereami")
 local flag = require("whereami.flag")
-local format = require("whereami.format")
+local formatter = require("whereami.format")
 local curl = require("plenary.curl")
 
 describe("whereami", function()
@@ -399,9 +399,9 @@ describe("whereami", function()
 	end)
 
 	it("formats private location fields without fetching data", function()
-		assert.are.equal("203.0.xxx.xxx", format.ip("203.0.113.42", { mask_ip = true }))
-		assert.are.equal("hidden", format.city("Springfield", { hide_city = true }))
-		assert.are.equal("hidden", format.isp("Example ISP", { hide_isp = true }))
+		assert.are.equal("203.0.xxx.xxx", formatter.ip("203.0.113.42", { mask_ip = true }))
+		assert.are.equal("hidden", formatter.city("Springfield", { hide_city = true }))
+		assert.are.equal("hidden", formatter.isp("Example ISP", { hide_isp = true }))
 	end)
 
 	it("masks IP addresses when privacy mask_ip is enabled", function()

--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -1,6 +1,7 @@
 local stub = require("luassert.stub")
 local whereami = require("whereami")
 local flag = require("whereami.flag")
+local format = require("whereami.format")
 local curl = require("plenary.curl")
 
 describe("whereami", function()
@@ -395,6 +396,14 @@ describe("whereami", function()
 
 		curl_stub:revert()
 		notify_stub:revert()
+	end)
+
+
+	it("formats private location fields without fetching data", function()
+		assert.are.equal("203.0.xxx.xxx", format.ip("203.0.113.42", { mask_ip = true }))
+		assert.are.equal("2001:db8:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx", format.ip("2001:db8::1", { mask_ip = true }))
+		assert.are.equal("hidden", format.city("Springfield", { hide_city = true }))
+		assert.are.equal("hidden", format.isp("Example ISP", { hide_isp = true }))
 	end)
 
 	it("masks IP addresses when privacy mask_ip is enabled", function()

--- a/lua/whereami/cache.lua
+++ b/lua/whereami/cache.lua
@@ -12,14 +12,17 @@ function M.clear()
 end
 
 function M.get(config, opts)
+	config = config or {}
 	opts = opts or {}
+	local hooks = config.hooks or {}
+	local cache_ttl = config.cache_ttl or 0
 	local now = vim.loop.now()
-	if not opts.refresh and config.cache_ttl > 0 and cache.data and (now - cache.updated_at) < config.cache_ttl then
+	if not opts.refresh and cache_ttl > 0 and cache.data and (now - cache.updated_at) < cache_ttl then
 		return cache.data
 	end
 
-	if config.hooks.before_request then
-		config.hooks.before_request(config)
+	if hooks.before_request then
+		hooks.before_request(config)
 	end
 
 	local parse_error = false
@@ -29,8 +32,8 @@ function M.get(config, opts)
 			cache.data = data
 			cache.updated_at = vim.loop.now()
 
-			if config.hooks.after_request then
-				config.hooks.after_request(data, config)
+			if hooks.after_request then
+				hooks.after_request(data, config)
 			end
 
 			return data

--- a/lua/whereami/cache.lua
+++ b/lua/whereami/cache.lua
@@ -1,0 +1,52 @@
+local M = {}
+local providers = require("whereami.providers")
+
+local cache = {
+	data = nil,
+	updated_at = 0,
+}
+
+function M.clear()
+	cache.data = nil
+	cache.updated_at = 0
+end
+
+function M.get(config, opts)
+	opts = opts or {}
+	local now = vim.loop.now()
+	if not opts.refresh and config.cache_ttl > 0 and cache.data and (now - cache.updated_at) < config.cache_ttl then
+		return cache.data
+	end
+
+	if config.hooks.before_request then
+		config.hooks.before_request(config)
+	end
+
+	local parse_error = false
+	for _, provider in ipairs(providers.list(config)) do
+		local data, err = providers.fetch(provider, config)
+		if data then
+			cache.data = data
+			cache.updated_at = vim.loop.now()
+
+			if config.hooks.after_request then
+				config.hooks.after_request(data, config)
+			end
+
+			return data
+		end
+		parse_error = parse_error or err == "Unable to parse location data."
+	end
+
+	if parse_error then
+		return nil, "Unable to parse location data."
+	end
+	return nil, "Unable to fetch location data."
+end
+
+function M.refresh(config)
+	M.clear()
+	return M.get(config, { refresh = true })
+end
+
+return M

--- a/lua/whereami/config.lua
+++ b/lua/whereami/config.lua
@@ -1,0 +1,42 @@
+local M = {}
+
+local default_config = {
+	providers = nil,
+	provider_url = nil,
+	timeout = 5000,
+	notification = {
+		title = "Where am I?",
+		icons = {
+			country_fallback = "🌎",
+			default = "❔",
+		},
+	},
+	default_command = "country",
+	cache_ttl = 300000,
+	privacy = {
+		mask_ip = false,
+		hide_city = false,
+		hide_isp = false,
+	},
+	hooks = {
+		before_request = nil,
+		after_request = nil,
+	},
+}
+
+local current_config = vim.deepcopy(default_config)
+
+function M.setup(opts)
+	current_config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), opts or {})
+	return current_config
+end
+
+function M.get()
+	return current_config
+end
+
+function M.defaults()
+	return vim.deepcopy(default_config)
+end
+
+return M

--- a/lua/whereami/format.lua
+++ b/lua/whereami/format.lua
@@ -1,0 +1,57 @@
+local M = {}
+local flag = require("whereami.flag")
+
+function M.country_icon(country, config)
+	return flag.get_flag(country, config.notification.icons.country_fallback)
+end
+
+function M.ip(ip, privacy)
+	privacy = privacy or {}
+	if not privacy.mask_ip then
+		return ip or "unknown"
+	end
+
+	if type(ip) ~= "string" or ip == "" then
+		return "hidden"
+	end
+
+	local first_octet, second_octet = ip:match("^(%d+)%.(%d+)%.%d+%.%d+$")
+	if first_octet and second_octet then
+		return first_octet .. "." .. second_octet .. ".xxx.xxx"
+	end
+
+	local first_group, second_group = ip:match("^([%x]+):([%x]+):")
+	if first_group and second_group then
+		return first_group .. ":" .. second_group .. ":xxxx:xxxx:xxxx:xxxx:xxxx:xxxx"
+	end
+
+	return "hidden"
+end
+
+function M.city(city, privacy)
+	if privacy and privacy.hide_city then
+		return "hidden"
+	end
+
+	return city or "unknown"
+end
+
+function M.isp(isp, privacy)
+	if privacy and privacy.hide_isp then
+		return "hidden"
+	end
+
+	return isp or "unknown"
+end
+
+function M.summary(data, config)
+	local icon = M.country_icon(data.country, config)
+	return table.concat({
+		"Country: " .. icon .. (data.country or "unknown"),
+		"City: " .. M.city(data.city, config.privacy),
+		"IP: " .. M.ip(data.ip, config.privacy),
+		"ISP: " .. M.isp(data.org, config.privacy),
+	}, "\n"), icon
+end
+
+return M

--- a/lua/whereami/format.lua
+++ b/lua/whereami/format.lua
@@ -2,7 +2,10 @@ local M = {}
 local flag = require("whereami.flag")
 
 function M.country_icon(country, config)
-	return flag.get_flag(country, config.notification.icons.country_fallback)
+	config = config or {}
+	local notification = config.notification or {}
+	local icons = notification.icons or {}
+	return flag.get_flag(country, icons.country_fallback)
 end
 
 function M.ip(ip, privacy)
@@ -45,12 +48,15 @@ function M.isp(isp, privacy)
 end
 
 function M.summary(data, config)
+	data = data or {}
+	config = config or {}
+	local privacy = config.privacy or {}
 	local icon = M.country_icon(data.country, config)
 	return table.concat({
 		"Country: " .. icon .. (data.country or "unknown"),
-		"City: " .. M.city(data.city, config.privacy),
-		"IP: " .. M.ip(data.ip, config.privacy),
-		"ISP: " .. M.isp(data.org, config.privacy),
+		"City: " .. M.city(data.city, privacy),
+		"IP: " .. M.ip(data.ip, privacy),
+		"ISP: " .. M.isp(data.org, privacy),
 	}, "\n"), icon
 end
 

--- a/lua/whereami/init.lua
+++ b/lua/whereami/init.lua
@@ -1,7 +1,7 @@
 local M = {}
 local cache = require("whereami.cache")
 local config = require("whereami.config")
-local format = require("whereami.format")
+local formatter = require("whereami.format")
 
 local available_options = { "all", "city", "country", "ip", "isp", "json", "refresh" }
 
@@ -40,7 +40,7 @@ end
 
 local function notify_country(data)
 	local cfg = current_config()
-	local icon = format.country_icon(data.country, cfg)
+	local icon = formatter.country_icon(data.country, cfg)
 	notify("You are in " .. icon .. (data.country or "unknown"), icon)
 end
 
@@ -79,7 +79,7 @@ function M.city()
 	end
 
 	local cfg = current_config()
-	notify("You are in " .. format.city(data.city, cfg.privacy), cfg.notification.icons.default)
+	notify("You are in " .. formatter.city(data.city, cfg.privacy), cfg.notification.icons.default)
 end
 
 function M.ip()
@@ -90,7 +90,7 @@ function M.ip()
 	end
 
 	local cfg = current_config()
-	notify("Your IP is " .. format.ip(data.ip, cfg.privacy), cfg.notification.icons.default)
+	notify("Your IP is " .. formatter.ip(data.ip, cfg.privacy), cfg.notification.icons.default)
 end
 
 function M.isp()
@@ -101,7 +101,7 @@ function M.isp()
 	end
 
 	local cfg = current_config()
-	notify("Your ISP is " .. format.isp(data.org, cfg.privacy), cfg.notification.icons.default)
+	notify("Your ISP is " .. formatter.isp(data.org, cfg.privacy), cfg.notification.icons.default)
 end
 
 function M.all()
@@ -111,7 +111,7 @@ function M.all()
 		return
 	end
 
-	local summary, icon = format.summary(data, current_config())
+	local summary, icon = formatter.summary(data, current_config())
 	notify(summary, icon)
 end
 

--- a/lua/whereami/init.lua
+++ b/lua/whereami/init.lua
@@ -1,6 +1,7 @@
 local M = {}
-local providers = require("whereami.providers")
-local flag = require("whereami.flag")
+local cache = require("whereami.cache")
+local config = require("whereami.config")
+local format = require("whereami.format")
 
 local available_options = { "all", "city", "country", "ip", "isp", "json", "refresh" }
 
@@ -12,161 +13,55 @@ local function is_available_option(option)
 	return vim.tbl_contains(available_options, option)
 end
 
-local default_config = {
-	providers = nil,
-	provider_url = nil,
-	timeout = 5000,
-	notification = {
-		title = "Where am I?",
-		icons = {
-			country_fallback = "🌎",
-			default = "❔",
-		},
-	},
-	default_command = "country",
-	cache_ttl = 300000,
-	privacy = {
-		mask_ip = false,
-		hide_city = false,
-		hide_isp = false,
-	},
-	hooks = {
-		before_request = nil,
-		after_request = nil,
-	},
-}
+local function current_config()
+	return config.get()
+end
 
-local config = vim.deepcopy(default_config)
-local cache = {
-	data = nil,
-	updated_at = 0,
-}
+local function get_data(opts)
+	return cache.get(current_config(), opts)
+end
 
-local function merge_config(opts)
-	config = vim.tbl_deep_extend("force", vim.deepcopy(default_config), opts or {})
+local function notify(message, icon)
+	local cfg = current_config()
+	vim.notify(message, vim.log.levels.INFO, { title = cfg.notification.title, icon = icon })
 end
 
 local function notify_error(message)
-	vim.notify(message, vim.log.levels.ERROR, { title = config.notification.title, icon = "❌" })
+	vim.notify(message, vim.log.levels.ERROR, { title = current_config().notification.title, icon = "❌" })
 end
 
 local function notify_unknown_option(option)
 	vim.notify(
 		"Unknown option: " .. option .. "\nAvailable options: " .. available_options_text(),
 		vim.log.levels.WARN,
-		{ title = config.notification.title }
+		{ title = current_config().notification.title }
 	)
 end
 
-local function get_data(opts)
-	opts = opts or {}
-	local now = vim.loop.now()
-	if not opts.refresh and config.cache_ttl > 0 and cache.data and (now - cache.updated_at) < config.cache_ttl then
-		return cache.data
-	end
-
-	if config.hooks.before_request then
-		config.hooks.before_request(config)
-	end
-
-	local parse_error = false
-	for _, provider in ipairs(providers.list(config)) do
-		local data, err = providers.fetch(provider, config)
-		if data then
-			cache.data = data
-			cache.updated_at = vim.loop.now()
-
-			if config.hooks.after_request then
-				config.hooks.after_request(data, config)
-			end
-
-			return data
-		end
-		parse_error = parse_error or err == "Unable to parse location data."
-	end
-
-	if parse_error then
-		return nil, "Unable to parse location data."
-	end
-	return nil, "Unable to fetch location data."
-end
-
-local function notify(message, icon)
-	vim.notify(message, vim.log.levels.INFO, { title = config.notification.title, icon = icon })
-end
-
-local function get_country_icon(country)
-	return flag.get_flag(country, config.notification.icons.country_fallback)
-end
-
 local function notify_country(data)
-	local icon = get_country_icon(data.country)
+	local cfg = current_config()
+	local icon = format.country_icon(data.country, cfg)
 	notify("You are in " .. icon .. (data.country or "unknown"), icon)
 end
 
-M.setup = function(opts)
-	merge_config(opts)
-	cache.data = nil
-	cache.updated_at = 0
+function M.setup(opts)
+	config.setup(opts)
+	cache.clear()
 end
 
-M.clear_cache = function()
-	cache.data = nil
-	cache.updated_at = 0
+function M.clear_cache()
+	cache.clear()
 end
 
-M.refresh = function()
-	M.clear_cache()
-	return get_data({ refresh = true })
+function M.refresh()
+	return cache.refresh(current_config())
 end
 
-M.get = function()
+function M.get()
 	return get_data()
 end
 
-local function mask_ip(ip)
-	if type(ip) ~= "string" or ip == "" then
-		return "hidden"
-	end
-
-	local first_octet, second_octet = ip:match("^(%d+)%.(%d+)%.%d+%.%d+$")
-	if first_octet and second_octet then
-		return first_octet .. "." .. second_octet .. ".xxx.xxx"
-	end
-
-	local first_group, second_group = ip:match("^([%x]+):([%x]+):")
-	if first_group and second_group then
-		return first_group .. ":" .. second_group .. ":xxxx:xxxx:xxxx:xxxx:xxxx:xxxx"
-	end
-
-	return "hidden"
-end
-
-local function format_ip(ip)
-	if config.privacy.mask_ip then
-		return mask_ip(ip)
-	end
-
-	return ip or "unknown"
-end
-
-local function format_city(city)
-	if config.privacy.hide_city then
-		return "hidden"
-	end
-
-	return city or "unknown"
-end
-
-local function format_isp(isp)
-	if config.privacy.hide_isp then
-		return "hidden"
-	end
-
-	return isp or "unknown"
-end
-
-M.country = function()
+function M.country()
 	local data, err = get_data()
 	if not data then
 		notify_error(err)
@@ -176,56 +71,52 @@ M.country = function()
 	notify_country(data)
 end
 
-M.city = function()
+function M.city()
 	local data, err = get_data()
 	if not data then
 		notify_error(err)
 		return
 	end
 
-	notify("You are in " .. format_city(data.city), config.notification.icons.default)
+	local cfg = current_config()
+	notify("You are in " .. format.city(data.city, cfg.privacy), cfg.notification.icons.default)
 end
 
-M.ip = function()
+function M.ip()
 	local data, err = get_data()
 	if not data then
 		notify_error(err)
 		return
 	end
 
-	notify("Your IP is " .. format_ip(data.ip), config.notification.icons.default)
+	local cfg = current_config()
+	notify("Your IP is " .. format.ip(data.ip, cfg.privacy), cfg.notification.icons.default)
 end
 
-M.isp = function()
+function M.isp()
 	local data, err = get_data()
 	if not data then
 		notify_error(err)
 		return
 	end
 
-	notify("Your ISP is " .. format_isp(data.org), config.notification.icons.default)
+	local cfg = current_config()
+	notify("Your ISP is " .. format.isp(data.org, cfg.privacy), cfg.notification.icons.default)
 end
 
-M.all = function()
+function M.all()
 	local data, err = get_data()
 	if not data then
 		notify_error(err)
 		return
 	end
 
-	local icon = get_country_icon(data.country)
-	local summary = table.concat({
-		"Country: " .. icon .. (data.country or "unknown"),
-		"City: " .. format_city(data.city),
-		"IP: " .. format_ip(data.ip),
-		"ISP: " .. format_isp(data.org),
-	}, "\n")
-
+	local summary, icon = format.summary(data, current_config())
 	notify(summary, icon)
 end
 
-M.whereami = function()
-	local handler = M[config.default_command] or M.country
+function M.whereami()
+	local handler = M[current_config().default_command] or M.country
 	handler()
 end
 
@@ -238,8 +129,7 @@ vim.api.nvim_create_user_command("Whereami", function(opts)
 	end
 
 	if option == nil then
-		local handler = M[config.default_command] or M.country
-		handler()
+		M.whereami()
 		return
 	end
 


### PR DESCRIPTION
### Motivation
- Keep `lua/whereami/init.lua` small and focused to make it easier to extend providers, caching, config, and formatting without the file growing unwieldy. 
- Improve testability by exposing formatting helpers directly so tests no longer need to reach into private upvalues. 

### Description
- Extracted configuration handling into `lua/whereami/config.lua` and moved the default config and `setup`/`get` helpers there. 
- Moved cache, TTL, provider iteration, hooks, and refresh logic into `lua/whereami/cache.lua`. 
- Moved country icon lookup and privacy-aware formatting for IP, city, ISP, and the summary into `lua/whereami/format.lua`. 
- Updated `lua/whereami/init.lua` to delegate to the new modules and kept it as the public API / command registration surface. 
- Updated tests to require `whereami.format` and added a unit asserting the privacy formatting behavior. 

### Testing
- Attempted to run the Plenary/Busted test suite with `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa`, but it could not be executed in this environment because `nvim` is not installed. (failed) 
- Ran `git diff --check` to validate the working tree for whitespace/merge issues, which completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511e35a9a4832891de5569170f2bde)