### PR TITLE
docs: add VPN workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ You can use the command or the API
 
 Run `:Whereami` to display the country you are in.
 
+For VPN testing, run `:Whereami all` after connecting or switching servers to
+confirm that your country, city, IP address, and ISP match the expected VPN exit
+location. Use `:Whereami refresh` first if you want to bypass cached location
+data and force a fresh provider request.
+
 You can also provide an argument:
 
 - `:Whereami country`: Show the country location where your request originated from.
@@ -195,6 +200,22 @@ vim.keymap.set("n", "<leader>l", whereami.country, { desc = "Show the country" }
 vim.keymap.set("n", "<leader>e", whereami.city, { desc = "Show the city" })
 vim.keymap.set("n", "<leader>i", whereami.ip, { desc = "Show the ip" })
 vim.keymap.set("n", "<leader>s", whereami.isp, { desc = "Show the ISP" })
+```
+
+For a VPN-focused workflow, bind the checks you run most often:
+
+```lua
+vim.keymap.set("n", "<leader>vc", require("whereami").country, {
+  desc = "Check VPN country",
+})
+
+vim.keymap.set("n", "<leader>va", require("whereami").all, {
+  desc = "Check VPN location details",
+})
+
+vim.keymap.set("n", "<leader>vr", require("whereami").refresh, {
+  desc = "Refresh VPN location",
+})
 ```
 
 


### PR DESCRIPTION
### Motivation

- Make the README more helpful for VPN users by showing common workflows and keymaps for verifying VPN exit location from inside Neovim.

### Description

- Update README `Command` section to recommend using `:Whereami all` for VPN testing and to mention using `:Whereami refresh` to bypass cached provider data.
- Add VPN-focused keymap examples demonstrating `vim.keymap.set` bindings for `require("whereami").country`, `require("whereami").all`, and `require("whereami").refresh` (mapped to `<leader>vc`, `<leader>va`, and `<leader>vr`).

### Testing

- Ran the plugin test command `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa`, which failed because `nvim` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a512397b2e0832897b97ce3bd6dbfcd)