### PR TITLE
Add GitHub Actions CI and Selene configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,49 @@
-name: Tests
+name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
+    name: Lint and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Install Neovim
         run: |
           sudo apt-get update
           sudo apt-get install -y neovim
+
       - name: Install plenary.nvim
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/plenary/start
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/plenary/start/plenary.nvim
+
       - name: Check formatting
         uses: JohnnyMorganz/stylua-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: 2.5.2
           args: --check .
-      - name: Run tests
+
+      - name: Run Selene
+        uses: NTBBloodbath/selene-action@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: .
+
+      - name: Run plenary tests
         run: nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa
+
+      - name: Check README links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress README.md

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,5 @@
+std = "vim"
+exclude = ["lua/tests/**"]
+
+[lints]
+mixed_table = "allow"

--- a/vim.yml
+++ b/vim.yml
@@ -1,0 +1,7 @@
+---
+base: lua51
+lua_versions:
+  - luajit
+globals:
+  vim:
+    any: true


### PR DESCRIPTION
### Motivation
- Add automated CI to catch regressions by running formatting, linting, unit tests and a README link check on PRs and pushes.
- Ensure repository follows the existing README guidance for running `plenary` tests and enforce code style with Stylua and Selene.

### Description
- Add a GitHub Actions workflow at `.github/workflows/test.yml` that runs on pushes to `main`, pull requests and manual dispatch and includes steps to checkout, install Neovim, install `plenary.nvim`, run a Stylua formatting check, run Selene, run Plenary/Busted tests, and check README links with Lychee.
- Configure workflow permissions to `contents: read` and use recent actions (`actions/checkout@v5`, `JohnnyMorganz/stylua-action@v5`, `NTBBloodbath/selene-action@v1.0.0`, `lycheeverse/lychee-action@v2`).
- Add a Selene configuration file `selene.toml` with `std = "vim"`, excluding `lua/tests/**`, and allowing `mixed_table` linting.

### Testing
- Parsed the workflow YAML with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml')"` which succeeded.
- Parsed TOML files with Python `tomllib` using a small script that loaded `.stylua.toml` and `selene.toml`, which succeeded.
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Attempted to run the Plenary test command `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa` but it was not executed locally because Neovim is not installed (`nvim: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a512338d4c4832890eaa7c4a2ec730b)