### PR TITLE
Improve test bootstrap dependency paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,38 @@ location data. By default, it tries `ipinfo.io` first and falls back to
 ## Testing
 
 The plugin uses [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) for
-its test suite. You can run the tests from the project root with:
+its test suite. The test bootstrap in `tests/minimal_init.lua` adds this plugin
+and common plenary checkout locations to Neovim's runtimepath.
+
+For local development, install Neovim and make plenary available in one of these
+ways:
+
+- Set `PLENARY_NVIM_PATH` to a plenary.nvim checkout. This is the recommended
+  option for CI because the dependency path is explicit.
+- Clone plenary.nvim into `.deps/plenary.nvim`, `deps/plenary.nvim`, or
+  `tests/deps/plenary.nvim` under this repository.
+- Install plenary.nvim with a package manager that checks it out to a standard
+  location such as `stdpath("data") .. "/lazy/plenary.nvim"` or
+  `stdpath("data") .. "/site/pack/vendor/start/plenary.nvim"`.
+
+Example local setup with a repository-local checkout:
+
+```bash
+git clone --depth 1 https://github.com/nvim-lua/plenary.nvim .deps/plenary.nvim
+```
+
+Run the tests from the project root with:
 
 ```bash
 nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa
 ```
 
-The command requires Neovim and plenary.nvim to be installed.
+The command requires Neovim and plenary.nvim to be installed. If plenary is not
+in one of the default locations above, pass it explicitly:
+
+```bash
+PLENARY_NVIM_PATH=/path/to/plenary.nvim nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa
+```
 
 See [SECURITY.md](SECURITY.md) for details on our security policy.
 

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,2 +1,24 @@
-vim.opt.runtimepath:append(".")
-vim.opt.runtimepath:append("lua")
+local function path_exists(path)
+	local stat = (vim.uv or vim.loop).fs_stat(path)
+	return stat and stat.type == "directory"
+end
+
+local function append_runtimepath(path)
+	if path and path ~= "" and path_exists(path) then
+		vim.opt.runtimepath:append(path)
+	end
+end
+
+local root = vim.fn.getcwd()
+
+append_runtimepath(root)
+append_runtimepath(root .. "/lua")
+
+-- Prefer an explicit checkout path in CI/local shells, then fall back to common
+-- package-manager and repository-local dependency locations.
+append_runtimepath(vim.env.PLENARY_NVIM_PATH)
+append_runtimepath(root .. "/.deps/plenary.nvim")
+append_runtimepath(root .. "/deps/plenary.nvim")
+append_runtimepath(root .. "/tests/deps/plenary.nvim")
+append_runtimepath(vim.fn.stdpath("data") .. "/lazy/plenary.nvim")
+append_runtimepath(vim.fn.stdpath("data") .. "/site/pack/vendor/start/plenary.nvim")


### PR DESCRIPTION
### Motivation

- Make the test bootstrap robust to CI and local dependency layouts by avoiding appending non-existent paths to Neovim's `runtimepath`.
- Allow CI to provide an explicit `plenary.nvim` checkout while still supporting common repository-local and package-manager locations.

### Description

- Update `tests/minimal_init.lua` to detect directories with `(vim.uv or vim.loop).fs_stat` and only append existing paths to `vim.opt.runtimepath`.
- Add support for an explicit `PLENARY_NVIM_PATH` and fallbacks for common plenary locations: `./.deps/plenary.nvim`, `./deps/plenary.nvim`, `./tests/deps/plenary.nvim`, `stdpath("data") .. "/lazy/plenary.nvim"`, and `stdpath("data") .. "/site/pack/vendor/start/plenary.nvim"`.
- Expand the README `Testing` section to document the bootstrap behavior, recommend `PLENARY_NVIM_PATH` for CI, provide a repository-local clone example, and include an explicit example showing how to run tests with `PLENARY_NVIM_PATH`.

### Testing

- Ran `git diff --check` which succeeded and reported no whitespace errors. 
- Attempted to run `nvim --headless -u tests/minimal_init.lua +'lua print(vim.o.runtimepath)' +qa` but `nvim` was not available in the environment so the command was not executed. 
- Attempted `luac -p tests/minimal_init.lua` but `luac` was not available in the environment so the syntax check was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51234576ac8328bbaba96d5607dc27)