### PR TITLE
Fix handling of blank location fields

### DIFF
--- a/lua/tests/whereami_spec.lua
+++ b/lua/tests/whereami_spec.lua
@@ -314,6 +314,53 @@ describe("whereami", function()
 		notify_stub:revert()
 	end)
 
+	it("uses unknown values for blank optional fields", function()
+		local curl_stub = stub(curl, "get", function()
+			return { body = "{\"country\":\"US\",\"city\":\"\",\"ip\":\"\",\"org\":\"\"}" }
+		end)
+		local notify_stub = stub(vim, "notify")
+
+		whereami.city()
+		whereami.ip()
+		whereami.isp()
+
+		assert
+			.stub(vim.notify)
+			.was_called_with("You are in unknown", vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+		assert
+			.stub(vim.notify)
+			.was_called_with("Your IP is unknown", vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+		assert
+			.stub(vim.notify)
+			.was_called_with("Your ISP is unknown", vim.log.levels.INFO, { title = "Where am I?", icon = "❔" })
+
+		curl_stub:revert()
+		notify_stub:revert()
+	end)
+
+	it("falls back when a provider response only has blank location fields", function()
+		local calls = 0
+		local curl_stub = stub(curl, "get", function(url)
+			calls = calls + 1
+			if url == "https://ipinfo.io/json" then
+				return { status = 200, body = "{\"ip\":\"\",\"city\":\"\",\"country\":\"\",\"org\":\"\"}" }
+			end
+
+			return { status = 200, body = "{\"country_code\":\"CA\",\"city\":\"Toronto\"}" }
+		end)
+		local notify_stub = stub(vim, "notify")
+
+		whereami.country()
+
+		assert.are.equal(2, calls)
+		assert
+			.stub(vim.notify)
+			.was_called_with("You are in 🇨🇦CA", vim.log.levels.INFO, { title = "Where am I?", icon = "🇨🇦" })
+
+		curl_stub:revert()
+		notify_stub:revert()
+	end)
+
 	it("falls back to the next default provider when the first provider fails", function()
 		local calls = 0
 		local curl_stub = stub(curl, "get", function(url)

--- a/lua/whereami/format.lua
+++ b/lua/whereami/format.lua
@@ -1,6 +1,10 @@
 local M = {}
 local flag = require("whereami.flag")
 
+local function present(value)
+	return value ~= nil and value ~= ""
+end
+
 function M.country_icon(country, config)
 	config = config or {}
 	local notification = config.notification or {}
@@ -11,7 +15,7 @@ end
 function M.ip(ip, privacy)
 	privacy = privacy or {}
 	if not privacy.mask_ip then
-		return ip or "unknown"
+		return present(ip) and ip or "unknown"
 	end
 
 	if type(ip) ~= "string" or ip == "" then
@@ -36,7 +40,7 @@ function M.city(city, privacy)
 		return "hidden"
 	end
 
-	return city or "unknown"
+	return present(city) and city or "unknown"
 end
 
 function M.isp(isp, privacy)
@@ -44,7 +48,7 @@ function M.isp(isp, privacy)
 		return "hidden"
 	end
 
-	return isp or "unknown"
+	return present(isp) and isp or "unknown"
 end
 
 function M.summary(data, config)
@@ -53,7 +57,7 @@ function M.summary(data, config)
 	local privacy = config.privacy or {}
 	local icon = M.country_icon(data.country, config)
 	return table.concat({
-		"Country: " .. icon .. (data.country or "unknown"),
+		"Country: " .. icon .. (present(data.country) and data.country or "unknown"),
 		"City: " .. M.city(data.city, privacy),
 		"IP: " .. M.ip(data.ip, privacy),
 		"ISP: " .. M.isp(data.org, privacy),

--- a/lua/whereami/providers.lua
+++ b/lua/whereami/providers.lua
@@ -47,8 +47,15 @@ local function is_single_provider(provider)
 	return provider.url ~= nil or provider.fetch ~= nil or provider.normalize ~= nil
 end
 
+local function has_location_value(value)
+	return value ~= nil and value ~= ""
+end
+
 local function has_location_field(data)
-	return data.ip ~= nil or data.city ~= nil or data.country ~= nil or data.org ~= nil
+	return has_location_value(data.ip)
+		or has_location_value(data.city)
+		or has_location_value(data.country)
+		or has_location_value(data.org)
 end
 
 local function unwrap_response(response)


### PR DESCRIPTION
### Motivation

- Provider responses that contain empty string fields were being treated as valid, preventing fallback to other providers and resulting in empty notifications instead of meaningful fallback values. 
- Notification and summary formatting displayed blank strings rather than the intended `unknown` placeholder for optional fields.

### Description

- Treat blank string values as absent when validating provider responses by adding `has_location_value` and using it in `providers.list`/`providers.fetch` checks (`lua/whereami/providers.lua`).
- Ensure formatting functions treat blank values as `unknown` by adding a `present` helper and using it in `ip`, `city`, `isp`, and `summary` (`lua/whereami/format.lua`).
- Add regression tests covering blank optional fields and a provider that returns only blank fields so the code falls back to the next provider (`lua/tests/whereami_spec.lua`).

### Testing

- Ran `git diff --check` which reported no whitespace or index issues. 
- Attempted to run the Plenary test suite with `nvim --headless -c "PlenaryBustedDirectory lua/tests {minimal_init = 'tests/minimal_init.lua'}" +qa`, but `nvim` was not available in the environment so tests were not executed. 
- `stylua --check .` and `selene .` were attempted but were not run because those tools are not installed in the environment.
- Added automated tests in `lua/tests/whereami_spec.lua` to cover the new behavior (not executed here due to missing `nvim`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5131ccb8b883288b76e136b8582d81)